### PR TITLE
solved unable to find myhdl.vpi problem for IVerilog Runtime Version 12.0

### DIFF
--- a/tb/test_uart_rx.py
+++ b/tb/test_uart_rx.py
@@ -90,7 +90,7 @@ def bench():
         raise Exception("Error running build command")
 
     dut = Cosimulation(
-        "vvp -m myhdl %s.vvp -lxt2" % testbench,
+        "vvp -m ./myhdl %s.vvp -lxt2" % testbench,
         clk=clk,
         rst=rst,
         current_test=current_test,

--- a/tb/test_uart_tx.py
+++ b/tb/test_uart_tx.py
@@ -89,7 +89,7 @@ def bench():
         raise Exception("Error running build command")
     
     dut = Cosimulation(
-        "vvp -m myhdl %s.vvp -lxt2" % testbench,
+        "vvp -m ./myhdl %s.vvp -lxt2" % testbench,
         clk=clk,
         rst=rst,
         current_test=current_test,


### PR DESCRIPTION
It is recommended to place myhdl.vpi file to location where *.vpp file is. However, *.vpp file can not locate it by itself. 